### PR TITLE
gspy_triggers

### DIFF
--- a/gravityspy/utils/utils.py
+++ b/gravityspy/utils/utils.py
@@ -277,8 +277,8 @@ def label_q_scans(plot_directory, path_to_cnn, **kwargs):
     return scores_table
 
 
-def get_gspy_triggers(start_time, end_time, ifo, label=False, confidence=0.0,
-                      savefile=False):
+def gspy_triggers(start_time, end_time, ifo, label=False, confidence=0.0,
+                  snr_low=7.50, snr_high=30000.0, savefile=False):
     """Fetches triggers classified by GravitySpy.
 
        This utility returns a  pandas dataframe of triggers as classified by
@@ -309,6 +309,7 @@ def get_gspy_triggers(start_time, end_time, ifo, label=False, confidence=0.0,
     if label:
         filters = ['ml_label={}'.format(label),
                    '{0}<=ml_confidence<=1.0'.format(confidence),
+                   '{0}<=snr<={1}'.format(snr_low, snr_high),
                    'ifo={0}'.format(ifo),
                    '{0:d}<event_time<{1:d}'.format(int(start_time),
                                                    int(end_time))]
@@ -316,6 +317,7 @@ def get_gspy_triggers(start_time, end_time, ifo, label=False, confidence=0.0,
                    end_time, confidence)
     else:
         filters = ['{0}<=ml_confidence<=1.0'.format(confidence),
+                   '{0}<=snr<={1}'.format(snr_low, snr_high),
                    'ifo={0}'.format(ifo),
                    '{0:d}<event_time<{1:d}'.format(int(start_time),
                                                    int(end_time))]
@@ -328,7 +330,7 @@ def get_gspy_triggers(start_time, end_time, ifo, label=False, confidence=0.0,
     dft = t.to_pandas()
     cols = ['event_time', 'snr', 'peak_frequency', 'duration',
             'amplitude', 'central_freq', 'bandwidth', 'chisq', 'chisq_dof',
-            'q_value', 'channel', 'gravityspy_id', 'q_value',
+            'channel', 'gravityspy_id', 'q_value',
             'ml_label', 'ml_confidence', 'ifo']
 
     dft = dft[cols]

--- a/gravityspy/utils/utils.py
+++ b/gravityspy/utils/utils.py
@@ -316,7 +316,7 @@ def gspy_triggers(start_time, end_time, ifo, label=False, confidence=0.0,
                    '{0:d}<event_time<{1:d}'.format(int(start_time),
                                                    int(end_time))]
         filename = '{0}_{1}_{2}_{3}_{4}.csv'.format(ifo, label, start_time,
-                   end_time, confidence)
+                                                    end_time, confidence)
     else:
         filters = ['{0}<=ml_confidence<=1.0'.format(confidence),
                    '{0}<=snr<={1}'.format(snr_low, snr_high),

--- a/gravityspy/utils/utils.py
+++ b/gravityspy/utils/utils.py
@@ -29,6 +29,7 @@ import numpy
 import h5py
 import os
 import pandas
+from gwpy.table import EventTable
 import matplotlib.pyplot as plt
 
 class GravitySpyConfigFile(object):
@@ -274,6 +275,70 @@ def label_q_scans(plot_directory, path_to_cnn, **kwargs):
     scores_table['ml_confidence'] = scores.max(1)
 
     return scores_table
+
+
+def get_gspy_triggers(start_time, end_time, ifo, label=False, confidence=0.0,
+                      savefile=False):
+    """Fetches triggers classified by GravitySpy.
+
+       This utility returns a  pandas dataframe of triggers as classified by
+       GravitySpy between a given start and end time with a given confidence
+       threshold.
+
+       Parameters
+       ---------
+       start_time, end_time : `str` or `float`
+           start and end GPS times for this analysis
+       ifo : `str`
+           string denoting the interferometer, e.g. ``'H1'`` for Hanford
+       label : 'str', optional
+           glitch class label, e.g. ``'Blip'``
+       confidence : 'float', optional
+           minimum machine learning confidence, between 0.0 and 1.0
+       savefile : 'bool', optional
+           if True, will save the data in a csv file
+
+       Returns
+       -------
+       tabular data : 'pandas.core.frame.DataFrame'
+       a catalogue of triggers classifed by GravitySpyi
+    """
+
+    table = 'glitches_v2d0'
+
+    if label:
+        filters = ['ml_label={}'.format(label),
+                   '{0}<=ml_confidence<=1.0'.format(confidence),
+                   'ifo={0}'.format(ifo),
+                   '{0:d}<event_time<{1:d}'.format(int(start_time),
+                                                   int(end_time))]
+        filename = '{0}_{1}_{2}_{3}_{4}.csv'.format(ifo, label, start_time,
+                   end_time, confidence)
+    else:
+        filters = ['{0}<=ml_confidence<=1.0'.format(confidence),
+                   'ifo={0}'.format(ifo),
+                   '{0:d}<event_time<{1:d}'.format(int(start_time),
+                                                   int(end_time))]
+        filename = '{0}_{1}_{2}_{3}_{4}.csv'.format(ifo, 'all', start_time,
+                                                    end_time, confidence)
+
+    t = EventTable.fetch('gravityspy', table, selection=filters,
+                         host='gravityspyplus.ciera.northwestern.edu')
+
+    dft = t.to_pandas()
+    cols = ['event_time', 'snr', 'peak_frequency', 'duration',
+            'amplitude', 'central_freq', 'bandwidth', 'chisq', 'chisq_dof',
+            'q_value', 'channel', 'gravityspy_id', 'q_value',
+            'ml_label', 'ml_confidence', 'ifo']
+
+    dft = dft[cols]
+
+    if savefile:
+        df = t.to_pandas()
+        df = df[cols]
+        df.to_csv(filename, index=None)
+    return dft
+
 
 def label_select_images(filename1, filename2, filename3, filename4,
                         path_to_cnn, **kwargs):

--- a/gravityspy/utils/utils.py
+++ b/gravityspy/utils/utils.py
@@ -301,7 +301,7 @@ def get_gspy_triggers(start_time, end_time, ifo, label=False, confidence=0.0,
        Returns
        -------
        tabular data : 'pandas.core.frame.DataFrame'
-       a catalogue of triggers classifed by GravitySpyi
+       a catalogue of triggers classifed by GravitySpy
     """
 
     table = 'glitches_v2d0'

--- a/gravityspy/utils/utils.py
+++ b/gravityspy/utils/utils.py
@@ -295,6 +295,8 @@ def gspy_triggers(start_time, end_time, ifo, label=False, confidence=0.0,
            glitch class label, e.g. ``'Blip'``
        confidence : 'float', optional
            minimum machine learning confidence, between 0.0 and 1.0
+       snr_low, snr_high : 'float', optional
+           minimum and maximum SNR for the analysis
        savefile : 'bool', optional
            if True, will save the data in a csv file
 


### PR DESCRIPTION
Added a function in utils.py to fetch triggers classified by GravitySpy. This will allow users to obtain the data in the format of a pandas Dataframe, the function gives the option to save the data in a csv file.  

The following bit of code will fetch all the triggers labeled as Fast_Scattering at L1 between Nov 5 and Nov 15 in O3b with SNR between 12 and 18 and confidence above 0.8.

`from gwpy.time import to_gps, from_gps`
`t1, t2 = to_gps('2019-11-05'), to_gps('2019-11-15')`
`from gravityspy.utils.utils import gspy_triggers`
`gspy_triggers(t1, t2, label='Fast_Scattering', ifo = 'L1',  snr_low = 12.0, snr_high=18.0, confidence=0.8)`

